### PR TITLE
Upgrade to Eleventy `1.0.0-beta.10`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ netlify/functions/serverless/**
 !netlify/functions/serverless/index.js
 # Local Netlify folder
 .netlify
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "eleventy --serve"
   },
   "dependencies": {
-    "@11ty/eleventy": "1.0.0-canary.39",
+    "@11ty/eleventy": "^1.0.0-beta.10",
     "jsdom": "^16.6.0",
     "title-case": "^3.0.3",
     "valid-url": "^1.0.9"


### PR DESCRIPTION
In conversation with Ben I suggested trying to stay close to the current version of Eleventy v1 since we're relying on v1 features that may be in flux. This PR upgrades from the canary to the current version of the beta.

I ran the project locally and went through the basic actions on the home page to make sure everything worked. Aside from that do we have any tests we can run against the project to ensure that upgrading dependencies doesn't break anything?

Right now might be a good time to start thinking of a minimum viable end-to-end test while there is still a relatively small set of features to test.