### PR TITLE
Add `hideMessagesFrom` config parameter

### DIFF
--- a/netlify/functions/serverless/cleanse-query-parameters.js
+++ b/netlify/functions/serverless/cleanse-query-parameters.js
@@ -6,14 +6,13 @@ const VALID_PARAMETERS = {
 		validate: isBoolean,
 		transform: toBoolean
 	},
+	hideMessagesFrom: {
+		validate: isCommaSeparatedList,
+		transform: toStringArray
+	},
 	showCommands: {
 		validate: value => (isBoolean(value) || isCommaSeparatedList(value)),
-		transform: value => {
-			if (isBoolean(value)) {
-				return toBoolean(value);
-			}
-			return value.split(',');
-		}
+		transform: value => (isBoolean(value) ? toBoolean(value) : toStringArray(value))
 	},
 	showLatestMessages: {
 		validate: isPositiveInteger,
@@ -97,7 +96,18 @@ function isPositiveInteger(value) {
  * @returns {any} query parameter's value transformed into a more usable format
  */
 
-/** @type {Transformer} */
+/**
+ * @type {Transformer}
+ * @returns {string[]}
+ */
+function toStringArray(value) {
+	return value.split(',');
+}
+
+/**
+ * @type {Transformer}
+ * @returns {boolean}
+ */
 function toBoolean(value) {
 	return value === 'true' ? true : false;
 }

--- a/netlify/functions/serverless/cleanse-query-parameters.js
+++ b/netlify/functions/serverless/cleanse-query-parameters.js
@@ -8,7 +8,7 @@ const VALID_PARAMETERS = {
 	},
 	hideMessagesFrom: {
 		validate: isCommaSeparatedList,
-		transform: toStringArray
+		transform: value => toStringArray(value.toLowerCase())
 	},
 	showCommands: {
 		validate: value => (isBoolean(value) || isCommaSeparatedList(value)),

--- a/src/docs/configuration.html
+++ b/src/docs/configuration.html
@@ -27,6 +27,14 @@ layout: page.html
 			<td><code>false</code></td>
 			<td>Displays plausible but randomly generated messages instead of a live feed</td>
 		</tr>
+		<tr id="hideMessagesFrom">
+			<th scope="row">
+				<code><a href="#hideMessagesFrom">hideMessagesFrom</a></code>
+			</th>
+			<td>A comma-separated list of case-insensitive usernames</td>
+			<td><code>undefined</code></td>
+			<td>Does not display messages if sent by any users in the provided list</td>
+		</tr>
 		<tr id="showCommands">
 			<th scope="row">
 				<code><a href="#showCommands">showCommands</a></code>

--- a/src/scripts/handleChat.js
+++ b/src/scripts/handleChat.js
@@ -109,6 +109,11 @@ function formatLinks(messageContents) {
 }
 
 ComfyJS.onChat = function(user, messageContents, flags, self, extra) {
+	// If sender is blocklisted, don't even think about doing the rest of this
+	const hideSender = Array.isArray(window.CONFIG.hideMessagesFrom) && window.CONFIG.hideMessagesFrom.includes(user.toLowerCase());
+	if (hideSender) return;
+
+	// Assemble message node
 	const newMessage = document.createElement('li');
 
 	const sender = document.createElement('div');

--- a/src/scripts/handleChat.js
+++ b/src/scripts/handleChat.js
@@ -214,7 +214,6 @@ ComfyJS.onMessageDeleted = function(id, extra) {
 	if (messageToDelete) {
 		removeMessageFromDomAndShiftOthers(messageToDelete);
 	}
-	messageToDelete.remove();
 }
 
 function removeMessageFromDomAndShiftOthers(messageToDelete) {


### PR DESCRIPTION
Closes #16 

This PR adds an _optional_ `hideMessagesFrom` query parameter, which - if provided - expects a comma-separated list of case-insensitive usernames. If a message is sent from a user in that list, it won't be added to the DOM at all.

Replies to that message will still display the message and its sender in the reply snippet.