### PR TITLE
Fix lockup during showLatestMessages deletions

### DIFF
--- a/src/scripts/handleChat.mjs
+++ b/src/scripts/handleChat.mjs
@@ -250,8 +250,9 @@ ComfyJS.onChat = function (user, messageContents, flags, self, extra) {
 	const {showLatestMessages} = window.CONFIG;
 	if (showLatestMessages) {
 		while (
-			document.querySelectorAll('[data-twitch-message]').length >
-			showLatestMessages
+			document.querySelectorAll(
+				'[data-twitch-message]:not([data-twitch-message-display-status="deleting"])'
+			).length > showLatestMessages
 		) {
 			const oldestMessage = document.querySelector('[data-twitch-message]');
 			const oldestMessageId = oldestMessage.getAttribute('data-twitch-message');


### PR DESCRIPTION
Fixes #95 

The lockup described in #95 seems to have come from our new, staged, animatable way of deleting messages, which involves adding the `data-twitch-message-display-status="deleting"` attribute to the element and _then_ removing it from the DOM after it's had a chance to animate.

This was messing with this `while` loop:

```js
if (showLatestMessages) {
	while (
		document.querySelectorAll(
			'[data-twitch-message]'
		).length > showLatestMessages
	) {
		const oldestMessage = document.querySelector('[data-twitch-message]');
		const oldestMessageId = oldestMessage.getAttribute('data-twitch-message');
		removeMessage(oldestMessageId);
	}
}
```

...because while an element is in the process of getting deleted, it still exists, and was counting against the `showLatestMessages` check.

By updating the selector here to `[data-twitch-message]:not([data-twitch-message-display-status="deleting"]`, we only check messages that aren't on their way out yet — and the `while` loop won't get caught doing redundant work _ad infinitum_.