### PR TITLE
Improve inner selectors

### DIFF
--- a/src/scripts/handleChat.mjs
+++ b/src/scripts/handleChat.mjs
@@ -124,7 +124,7 @@ function formatUserMentions(messageContents) {
 function formatChatCommand(messageContents) {
 	const COMMAND_REGEX = /^!(([\w]|&#83;|&#115;)+)/;
 	return messageContents.replace(COMMAND_REGEX, function (substring, command) {
-		return `<mark class="twitch-chat-command">!${command}</mark>`;
+		return `<mark class="twitch-chat-command" data-twitch-command-inner="!${command}">!${command}</mark>`;
 	});
 }
 

--- a/src/scripts/handleChat.mjs
+++ b/src/scripts/handleChat.mjs
@@ -112,7 +112,7 @@ function formatUserMentions(messageContents) {
 	return messageContents.replace(
 		/@(([\w]|&#83;|&#115;)+)/g,
 		function (substring, mentionedUser) {
-			return `<mark data-twitch-mentioned-user="${mentionedUser}">@${mentionedUser}</mark>`;
+			return `<mark data-twitch-mentioned-user="@${mentionedUser}">@${mentionedUser}</mark>`;
 		}
 	);
 }


### PR DESCRIPTION
The showmy.chat philosophy has been to put selectors as high up as they can possibly go, so that any child can access that information. However, this poses a problem when you want to use those values in, say, an `attr()` function for an inner element's pseudo-elements — for instance, if you wanted to duplicate the sender name in the sender's pseudo-elements.

As a result, it makes sense to include _duplicate_ information on those nodes, so that theme contributors can more easily leverage `attr()` and pseudo-elements. This work began in 39502fd106e33ccd239ab451ff76309f39443f52 which, admittedly, I YOLO pushed during a Frontend Horse stream.

In this PR, I've added the name of the command to a command's `mark` tag, so a message that issues the `!uptime` command will now have a node that looks like `<mark class="twitch-chat-command" data-twitch-command-inner="!uptime">!uptime</mark>`. The inclusion of the `!` is intentional here, as CSS does not make concatenation easy, and very likely, this attribute will be used to exactly duplicate the contents of the `mark` tag.

In that vein, I've made a change that would technically constitute a **breaking change**, which is that I've added an `@` inside the attribute value for mentions' `mark` tags, so `<mark data-twitch-mentioned-user="SomeAnticsDev">` is now `<mark data-twitch-mentioned-user="@SomeAnticsDev">`. This could be a breaking change for some local themes, but I don't know of anyone who's actually using this, and the impact seems quite low. The risk/reward of this seems pretty good to me — minimal risk, but far higher chance that theme developers can more easily use this attribute as a style hook.