### PR TITLE
alerts endpoint

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,3 +4,10 @@ to = "/.netlify/functions/serverless"
 status = 200
 force = true
 _generated_by_eleventy_serverless = "serverless"
+
+[[redirects]]
+from = "/alerts/:channel"
+to = "/.netlify/functions/serverless"
+status = 200
+force = true
+_generated_by_eleventy_serverless = "serverless"

--- a/src/alerts/alerts.11tydata.js
+++ b/src/alerts/alerts.11tydata.js
@@ -1,0 +1,5 @@
+module.exports = {
+	permalink: {
+		serverless: '/alerts/:channel',
+	},
+};

--- a/src/alerts/alerts.html
+++ b/src/alerts/alerts.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+	<meta charset="UTF-8" />
+	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	<style>
+		:root {
+			color-scheme: light dark;
+		}
+	</style>
+	<link rel="stylesheet" href="{{ eleventy.serverless.query.theme | toStylesheet: themes }}" />
+	<script>
+		const config = JSON.parse(`{{ eleventy.serverless.query | serialize }}`);
+		window.CONFIG = Object.freeze(config);
+	</script>
+	{% if eleventy.serverless.query.DEMO %}
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/Faker/3.1.0/faker.min.js"></script>
+	<script src="/scripts/demo.mjs" type="module"></script>
+	{% else %}
+	<script src="https://cdn.jsdelivr.net/npm/comfy.js@latest/dist/comfy.min.js"></script>
+	{% endif %}
+	<title>{{ eleventy.serverless.path.channel }} | showmy.chat</title>
+</head>
+
+<body>
+	<dialog data-twitch-alert="{{ eleventy.serverless.path.channel }}"></dialog>
+	<!-- <script src="/scripts/bttvIntegration.mjs" type="module"></script> -->
+	<script src="/scripts/colorContrast.mjs" type="module"></script>
+	<script src="/scripts/handleAlerts.mjs" type="module"></script>
+	<script src="/scripts/utilities.mjs" type="module"></script>
+</body>
+
+</html>

--- a/src/scripts/demo.mjs
+++ b/src/scripts/demo.mjs
@@ -135,6 +135,101 @@ const MOCK_COMFY = (function () {
 		onMessageDeleted(id, extra) {},
 
 		/**
+		 * Responds to raid event
+		 *
+		 *
+		 * @param {string} user
+		 * @param viewers
+		 * @param extra
+		 */
+		onRaid(user, viewers, extra) {},
+
+		/**
+		 * Responds to user cheering
+		 *
+		 * @param {string} user
+		 * @param {string} message
+		 * @param bits
+		 * @param flags
+		 * @param extra
+		 */
+		onCheer(user, message, bits, flags, extra) {},
+
+		/**
+		 * Responds to user channel subscription
+		 *
+		 * @param {string} user
+		 * @param {string} message
+		 * @param subTierInfo
+		 * @param extra
+		 */
+		onSub(user, message, subTierInfo, extra) {},
+
+		/**
+		 * Responds to user channel subscription anniversary
+		 *
+		 * @param {string} user
+		 * @param {string} message
+		 * @param streamMonths
+		 * @param cumulativeMonths
+		 * @param subTierInfo
+		 * @param extra
+		 */
+		onResub(
+			user,
+			message,
+			streamMonths,
+			cumulativeMonths,
+			subTierInfo,
+			extra
+		) {},
+
+		/**
+		 * Responds to user gift subscription
+		 *
+		 * @param gifterUser
+		 * @param streakMonths
+		 * @param recipientUser
+		 * @param senderCount
+		 * @param subTierInfo
+		 * @param extra
+		 */
+		onSubGift(
+			gifterUser,
+			streakMonths,
+			recipientUser,
+			senderCount,
+			subTierInfo,
+			extra
+		) {},
+
+		/**
+		 * Responds to user sending gift subscriptions
+		 *
+		 * @param gifterUser
+		 * @param numbOfSubs
+		 * @param senderCount
+		 * @param subTierInfo
+		 * @param extra
+		 */
+		onSubMysteryGift(
+			gifterUser,
+			numbOfSubs,
+			senderCount,
+			subTierInfo,
+			extra
+		) {},
+
+		/**
+		 * Responds to user continuing gift subscription
+		 *
+		 * @param {string} user
+		 * @param sender
+		 * @param extra
+		 */
+		onGiftSubContinue(user, sender, extra) {},
+
+		/**
 		 * @param _
 		 * @param __
 		 * @param {string[]} [channelNames]
@@ -144,6 +239,7 @@ const MOCK_COMFY = (function () {
 				broadcaster.user = channelNames[0];
 			}
 			setTimeout(_generateNextMessage, 500);
+			setTimeout(_generateNextAlert, 500);
 		},
 	};
 
@@ -291,6 +387,27 @@ const MOCK_COMFY = (function () {
 
 		const duration = Math.floor(Math.random() * 2) + 2;
 		setTimeout(_generateNextMessage, duration * 1000);
+	}
+
+	/**
+	 * Generates a realistic message and "sends" it
+	 */
+	function _generateNextAlert() {
+		// Generate user
+		let chatter = _choose(allUsers);
+		const extra = {
+			id: faker.random.uuid(),
+			userState: {},
+			userColor: chatter.userColor,
+		};
+
+		// Publish alert
+		const raid = [chatter.user, Math.floor(Math.random() * 300), extra];
+		comfy.onRaid(...raid);
+
+		// Ready up the next alert
+		const duration = Math.random() * 10000;
+		setTimeout(_generateNextAlert, duration);
 	}
 
 	return comfy;

--- a/src/scripts/handleAlerts.mjs
+++ b/src/scripts/handleAlerts.mjs
@@ -1,0 +1,112 @@
+/* global ComfyJS */
+// we use the skypack CDN here because this isn't packaged correctly
+//  for the browser based ESM
+import {main, createQueue, sleep} from 'https://cdn.skypack.dev/effection';
+
+const alertbox = document.querySelector('[data-twitch-alert]');
+
+const watchedChannels = alertbox.getAttribute('data-twitch-alert');
+
+/**
+ *
+ */
+async function init() {
+	return main(function* () {
+		let messageBacklog = createQueue();
+
+		/**
+		 * @param {object} handleAlert
+		 * @param {string} handleAlert.user
+		 * @param {string} handleAlert.message
+		 * @param handleAlert.extra
+		 * @param handleAlert.messageBacklog
+		 */
+		function handleAlert({user, message, extra}) {
+			// Assemble alert node
+			const newAlert = document.createElement('div');
+			newAlert.innerHTML = message;
+			newAlert.classList.add('twitch-chat-message');
+			newAlert.setAttribute('data-twitch-message', extra.id);
+			newAlert.setAttribute('data-twitch-sender', user);
+
+			messageBacklog.send(newAlert);
+		}
+
+		ComfyJS.onRaid = function (user, viewers, extra = {}) {
+			const message = `${user} is raiding with ${viewers} viewers!`;
+			return handleAlert({user, message, extra});
+		};
+
+		ComfyJS.onCheer = function (user, message, bits, flags, extra) {
+			const composedMessage = `${user} cheered with ${bits}! ${message}`;
+			return handleAlert({
+				user,
+				message: composedMessage,
+				extra,
+			});
+		};
+
+		ComfyJS.onSub = function (user, message, subTierInfo, extra) {
+			const composedMessage = `${user} subscribed at ${subTierInfo}! ${message}`;
+			return handleAlert({
+				user,
+				message: composedMessage,
+				extra,
+			});
+		};
+
+		ComfyJS.onResub = function (
+			user,
+			message,
+			streamMonths,
+			cumulativeMonths,
+			subTierInfo,
+			extra
+		) {
+			const composedMessage = `${user} continued their subscription for ${cumulativeMonths}! ${message}`;
+			return handleAlert({user, message: composedMessage, extra});
+		};
+
+		ComfyJS.onSubGift = function (
+			gifterUser,
+			streakMonths,
+			recipientUser,
+			senderCount,
+			subTierInfo,
+			extra
+		) {
+			const composedMessage = `${gifterUser} gifted ${recipientUser} a subscription!`;
+			return handleAlert({user: gifterUser, message: composedMessage, extra});
+		};
+
+		ComfyJS.onSubMysteryGift = function (
+			gifterUser,
+			numbOfSubs,
+			senderCount,
+			subTierInfo,
+			extra
+		) {
+			const composedMessage = `${gifterUser} gifted ${numbOfSubs} ${
+				numbOfSubs > 1 ? 'subscriptions' : 'a subscription'
+			}!`;
+			return handleAlert({user: gifterUser, message: composedMessage, extra});
+		};
+
+		ComfyJS.onGiftSubContinue = function (user, sender, extra) {
+			const message = `${user} is continuing their subscription!`;
+			return handleAlert({user, message, extra});
+		};
+
+		ComfyJS.Init(null, null, watchedChannels.split(' '));
+
+		yield messageBacklog.forEach(function* (nextAlert) {
+			alertbox.open = true;
+			alertbox.append(nextAlert);
+			yield sleep(4000);
+			alertbox.open = false;
+			alertbox.replaceChildren();
+		});
+	});
+}
+
+init();


### PR DESCRIPTION
## Motivation

This PR is an exploration into adding an endpoint for showing alerts. It has the possibility that we take it to feature complete in this PR, in separate stages, or scrap it even.

## Progress

- Currently we have the beginnings of a `/alerts/*` endpoint which handles all alerts (except for follows).
- The alert content, semantic html, and css can all use some effort.
- There are the beginnings of a workable queue system that I think is in a place where we can easily extend it.
- The demo for `onRaid()` has been wired up. The other alerts still need to be wired up.

## For PR Completion

I would be interested in opinions on the viability of this, and any possible issues with the current architecture. I suspect we want to do the css separate for the alert html than the chat. Presuming this is the case, help or pointers with the html and css would be ❤️ .
