### PR TITLE
Enable users to disable animated emotes in their overlays

### DIFF
--- a/netlify/functions/serverless/cleanse-query-parameters.js
+++ b/netlify/functions/serverless/cleanse-query-parameters.js
@@ -12,6 +12,10 @@ const VALID_PARAMETERS = {
 		validate: isPositiveInteger,
 		transform: Number.parseInt,
 	},
+	disableAnimatedEmotes: {
+		validate: isBoolean,
+		transform: toBoolean,
+	},
 	hideMessagesFrom: {
 		validate: isCommaSeparatedList,
 		transform: (value) => toStringArray(value.toLowerCase()),

--- a/src/_data/defaults.js
+++ b/src/_data/defaults.js
@@ -2,6 +2,7 @@ module.exports = {
 	channel: 'showmychat',
 	clearMessageAfter: '',
 	DEMO: false,
+	disableAnimatedEmotes: false,
 	hideMessagesFrom: '',
 	showCommands: false,
 	showLatestMessages: 100,

--- a/src/docs/configuration.html
+++ b/src/docs/configuration.html
@@ -45,6 +45,14 @@ layout: page.html
 				Removes messages from the overlay after the specified time (in milliseconds) has elapsed
 			</td>
 		</tr>
+		<tr id="disable-animated-emotes">
+			<th scope="row">
+				<code><a href="#disable-animated-emotes">disableAnimatedEmotes</a></code>
+			</th>
+			<td><code>true</code> or <code>false</code></td>
+			<td><code>{{defaults.disableAnimatedEmotes}}</code></td>
+			<td>Displays static versions of animated emotes</td>
+		</tr>
 		<tr id="hide-messages-from">
 			<th scope="row">
 				<code><a href="#hide-messages-from">hideMessagesFrom</a></code>

--- a/src/index.html
+++ b/src/index.html
@@ -55,11 +55,15 @@ layout: page.html
 		<input type="number" id="clear-message-after" name="clearMessageAfter"
 			placeholder="{{defaults.clearMessageAfter}}" step="0.1" min="0" />
 
-		<div>
-			<input type="checkbox" id="disable-animated-emotes" name="disableAnimatedEmotes" value="true" />
-			<label for="disable-animated-emotes">
-				Disable Animated Emotes?
-			</label>
+		<div class="overlay-builder-header">
+			<div>
+				<input type="checkbox" id="disable-animated-emotes" name="disableAnimatedEmotes" value="true" />
+				<label for="disable-animated-emotes">
+					Disable Animated Emotes?
+				</label>
+			</div>
+			<a href="docs/configuration/#disable-animated-emotes"
+				aria-label="Docs for disableAnimatedEmotes">&#9432;</a>
 		</div>
 
 		<div>

--- a/src/index.html
+++ b/src/index.html
@@ -56,6 +56,13 @@ layout: page.html
 			placeholder="{{defaults.clearMessageAfter}}" step="0.1" min="0" />
 
 		<div>
+			<input type="checkbox" id="disable-animated-emotes" name="disableAnimatedEmotes" value="true" />
+			<label for="disable-animated-emotes">
+				Disable Animated Emotes?
+			</label>
+		</div>
+
+		<div>
 			<output></output>
 		</div>
 	</form>

--- a/src/scripts/handleChat.mjs
+++ b/src/scripts/handleChat.mjs
@@ -44,6 +44,8 @@ function htmlEntities(html) {
 	return html;
 }
 
+const emoteFormat = window.CONFIG.disableAnimatedEmotes ? 'static' : 'default';
+
 /**
  *
  * @param {string} text - message contents
@@ -68,7 +70,7 @@ function formatEmotes(text, emotes = {}) {
 					.slice(0, mote[0])
 					.concat(empty)
 					.concat(splitText.slice(mote[1] + 1, splitText.length));
-				let emoteSrc = `https://static-cdn.jtvnw.net/emoticons/v2/${emoteId}/default/light/3.0`;
+				let emoteSrc = `https://static-cdn.jtvnw.net/emoticons/v2/${emoteId}/${emoteFormat}/light/3.0`;
 				splitText.splice(
 					mote[0],
 					1,


### PR DESCRIPTION
Resolves #17 

Introduces a `disableAnimatedEmotes` overlay parameter that, when passed `true`, replaces animated emotes with [their static versions](https://help.twitch.tv/s/article/animated-emotes?language=en_US#:~:text=Thumbnail%20for%20the%20animated%20emote%20will%20default%20to%20the%20first%20frame%20of%20the%20GIF.%20If%20you%20want%20to%20create%20a%20different%20thumbnail%2C%20this%20can%20be%20overridden%20with%20a%20custom%20static%20image%20(same%20requirements%20as%20emotes)). This might be useful as an accessibility feature if folks find animated emotes (especially a whole overlay's worth) distracting or overwhelming.

This field defaults to `false` — in other words, animated emotes will animate by default.

See [Twitch's docs for building image CDN URLs for emote variants](https://dev.twitch.tv/docs/irc/emotes#using-the-cdn-url-template-to-create-an-image-url).