### PR TITLE
Wrap replied-to user within reply snippet in a span

### DIFF
--- a/src/scripts/handleChat.mjs
+++ b/src/scripts/handleChat.mjs
@@ -181,7 +181,7 @@ ComfyJS.onChat = function (user, messageContents, flags, self, extra) {
 			/\\s/g,
 			' '
 		);
-		replyPreview.innerHTML = `Replying to @${extra.userState['reply-parent-display-name']}: ${repliedMessage}`;
+		replyPreview.innerHTML = `Replying to <span data-twitch-replied-user="@${extra.userState['reply-parent-display-name']}">@${extra.userState['reply-parent-display-name']}</span>: ${repliedMessage}`;
 		newMessage.appendChild(replyPreview);
 	}
 


### PR DESCRIPTION
Resolves #33 

In reply snippets, there's a little bit that says something like `Replying to @BenDMyers:`, before displaying the message body of the message that was replied to. This PR wraps that `@BenDMyers` part in a span with `data-twitch-replied-user` set to the user that was replied to. This shouldn't impact any preexisting styles, but it will enable theme devs to target that specific span and style the user being replied to.