### PR TITLE
Ensure long words and URLs break and wrap to the next line instead of causing overflows

### DIFF
--- a/src/scripts/demo.mjs
+++ b/src/scripts/demo.mjs
@@ -195,6 +195,23 @@ const MOCK_COMFY = (function () {
 			flags.highlighted = true;
 		}
 
+		// Randomly add a long-ish URL
+		if (Math.random() < 0.07) {
+			/** @type {string[]} */
+			const words = messageContents.split(' ');
+			const minimumIndex = isReply ? 1 : 0;
+			const insertionIndex = Math.max(
+				minimumIndex,
+				Math.floor(Math.random() * words.length)
+			);
+			words.splice(
+				insertionIndex,
+				0,
+				`https://www.twitch.tv/videos/1315188393`
+			);
+			messageContents = words.join(' ');
+		}
+
 		// Randomly add emotes
 		if (Math.random() < 0.3) {
 			/** @type {string[]} */

--- a/src/theme-template.css
+++ b/src/theme-template.css
@@ -44,6 +44,8 @@ body {
 /* Style the message contents themselves */
 .twitch-chat-message {
 	/* Message contents styles here */
+
+	word-break: break-word;
 }
 
 /* Style chat emotes */

--- a/src/themes/alex-party.css
+++ b/src/themes/alex-party.css
@@ -73,6 +73,7 @@ body {
 
 [data-twitch-message] .twitch-chat-message {
 	display: inline;
+	word-break: break-word;
 }
 
 [data-twitch-emote] {

--- a/src/themes/default.css
+++ b/src/themes/default.css
@@ -74,6 +74,7 @@ body {
 
 [data-twitch-message] .twitch-chat-message {
 	display: inline;
+	word-break: break-word;
 }
 
 [data-twitch-message-status*='highlighted'] .twitch-chat-message {

--- a/src/themes/frontend-horse.css
+++ b/src/themes/frontend-horse.css
@@ -189,6 +189,7 @@ body {
 	color: var(--chat-text-color);
 	display: inline;
 	line-height: 24px;
+	word-break: break-word;
 }
 
 .twitch-chat-command {

--- a/src/themes/horse-horse-horse.css
+++ b/src/themes/horse-horse-horse.css
@@ -99,6 +99,7 @@ body {
 	padding-right: 12px;
 	padding-top: 1px;
 	position: relative;
+	word-break: break-word;
 }
 
 .twitch-chat-message::before {

--- a/src/themes/light.css
+++ b/src/themes/light.css
@@ -68,6 +68,7 @@ body {
 
 [data-twitch-message] .twitch-chat-message {
 	display: inline;
+	word-break: break-word;
 }
 
 [data-twitch-message-status*='highlighted'] .twitch-chat-message {

--- a/src/themes/peruvian-idol.css
+++ b/src/themes/peruvian-idol.css
@@ -75,6 +75,7 @@ body {
 	margin-bottom: 0.125em;
 	color: var(--color-text-default);
 	order: 1;
+	word-break: break-word;
 }
 
 .twitch-chat-sender::after {

--- a/src/themes/retro-swirly.css
+++ b/src/themes/retro-swirly.css
@@ -155,6 +155,7 @@ body {
 
 [data-twitch-message] .twitch-chat-message {
 	display: inline;
+	word-break: break-word;
 }
 
 [data-twitch-emote] {


### PR DESCRIPTION
Resolves #158 

Turns out putting `word-break: break-word;` on the message nodes should basically be required for all themes — otherwise, long words and URLs will cause some serious overflow issues. Some themes already had this; now all of them do. In addition, this line has been added to the theme template stylesheet, so hopefully new theme developers can take advantage of it.