### PR TITLE
Expose a stylehook for "/me" messages

### DIFF
--- a/src/scripts/demo.mjs
+++ b/src/scripts/demo.mjs
@@ -190,9 +190,12 @@ const MOCK_COMFY = (function () {
 			}
 		}
 
-		// Randomly highlight messages
 		if (Math.random() < 0.1) {
+			// Randomly highlight messages
 			flags.highlighted = true;
+		} else if (Math.random() < 0.08) {
+			// Randomly mark messages as actions (i.e. user started message with "/me")
+			extra.messageType = 'action';
 		}
 
 		// Randomly add a long-ish URL

--- a/src/scripts/handleChat.mjs
+++ b/src/scripts/handleChat.mjs
@@ -158,7 +158,7 @@ function formatChatCommand(messageContents) {
 // 	});
 // }
 
-ComfyJS.onChat = function (user, messageContents, flags, self, extra) {
+ComfyJS.onChat = function (user, messageContents, flags, self, extra = {}) {
 	// If sender is blocklisted, don't even think about doing the rest of this
 	const hideSender =
 		Array.isArray(window.CONFIG.hideMessagesFrom) &&
@@ -223,6 +223,7 @@ ComfyJS.onChat = function (user, messageContents, flags, self, extra) {
 	const messageStatus = [];
 	if (flags.highlighted) messageStatus.push('highlighted');
 	if (flags.customReward) messageStatus.push('customReward');
+	if (extra.messageType === 'action') messageStatus.push('action');
 	if (messageStatus.length > 0) {
 		newMessage.setAttribute(
 			'data-twitch-message-status',

--- a/src/themes/candy-stripes-dark.css
+++ b/src/themes/candy-stripes-dark.css
@@ -144,7 +144,11 @@ body {
 	margin: -0.6em -0.4em;
 }
 
-[data-twitch-message][data-twitch-message-status='highlighted'] > * {
+[data-twitch-message][data-twitch-message-status~='highlighted'] > * {
 	background-color: var(--white-transparent);
 	color: var(--black-transparent);
+}
+
+[data-twitch-message-status~='action'] .twitch-chat-message {
+	font-style: italic;
 }

--- a/src/themes/default.css
+++ b/src/themes/default.css
@@ -77,10 +77,14 @@ body {
 	word-break: break-word;
 }
 
-[data-twitch-message-status*='highlighted'] .twitch-chat-message {
+[data-twitch-message-status~='highlighted'] .twitch-chat-message {
 	background-color: var(--twitch-highlight-purple);
 	border: 4px solid var(--twitch-highlight-purple);
 	color: white;
+}
+
+[data-twitch-message-status~='action'] .twitch-chat-message {
+	font-style: italic;
 }
 
 [data-twitch-emote] {

--- a/src/themes/light.css
+++ b/src/themes/light.css
@@ -71,10 +71,14 @@ body {
 	word-break: break-word;
 }
 
-[data-twitch-message-status*='highlighted'] .twitch-chat-message {
+[data-twitch-message-status~='highlighted'] .twitch-chat-message {
 	background-color: var(--twitch-highlight-purple);
 	border: 4px solid var(--twitch-highlight-purple);
 	color: white;
+}
+
+[data-twitch-message-status~='action'] .twitch-chat-message {
+	font-style: italic;
 }
 
 .twitch-chat-command {

--- a/src/themes/pride-dark.css
+++ b/src/themes/pride-dark.css
@@ -134,7 +134,11 @@ body {
 	margin: -0.6em -0.4em;
 }
 
-[data-twitch-message][data-twitch-message-status='highlighted'] > * {
+[data-twitch-message][data-twitch-message-status~='highlighted'] > * {
 	background-color: var(--white-transparent);
 	color: var(--black-transparent);
+}
+
+[data-twitch-message-status~='action'] .twitch-chat-message {
+	font-style: italic;
 }

--- a/src/themes/trans-pride-stripes.css
+++ b/src/themes/trans-pride-stripes.css
@@ -121,8 +121,8 @@ body {
 	color: var(--white);
 }
 
-[data-twitch-message-status='highlighted'] [data-twitch-mentioned-user],
-[data-twitch-message-status='highlighted'] .twitch-chat-command {
+[data-twitch-message-status~='highlighted'] [data-twitch-mentioned-user],
+[data-twitch-message-status~='highlighted'] .twitch-chat-command {
 	filter: brightness(85%) saturate(120%);
 }
 
@@ -136,7 +136,11 @@ body {
 	margin: -0.6em -0.4em;
 }
 
-[data-twitch-message][data-twitch-message-status='highlighted'] > * {
+[data-twitch-message][data-twitch-message-status~='highlighted'] > * {
 	background-color: var(--white-transparent);
 	color: var(--black-transparent);
+}
+
+[data-twitch-message-status~='action'] .twitch-chat-message {
+	font-style: italic;
 }


### PR DESCRIPTION
Twitch chatters can start their message with `/me` to indicate they're describing their actions in the third-person. The native Twitch chat widget will strip the `/me` part of that message, and italicize the rest.

For instance, if the user types:
> /me blinks slowly

...Twitch will show:
> *blinks slowly*

Behind the scenes, Twitch exposes `/me` messages as a different message type than regular messages, called `"action"`.  This pull request exposes that `action` message type as part of the `data-twitch-message-status` attribute. Themes will be able to use this to, for instance, italicize the message, or inject asterisks, or whichever other presentation they desire.