### PR TITLE
add static demo option

### DIFF
--- a/netlify/functions/serverless/cleanse-query-parameters.js
+++ b/netlify/functions/serverless/cleanse-query-parameters.js
@@ -5,8 +5,8 @@ const defaults = require('../../../src/_data/defaults');
  */
 const VALID_PARAMETERS = {
 	DEMO: {
-		validate: isBoolean,
-		transform: toBoolean,
+		validate: (value) => isBoolean(value) || value === 'static',
+		transform: (value) => (isBoolean(value) ? toBoolean(value) : value),
 	},
 	clearMessageAfter: {
 		validate: isPositiveInteger,

--- a/src/docs/configuration.html
+++ b/src/docs/configuration.html
@@ -28,7 +28,7 @@ description: All parameters for showmy.chat overlay URLs.
 			<th scope="row">
 				<code><a href="#demo">DEMO</a></code>
 			</th>
-			<td><code>true</code> or <code>false</code></td>
+			<td><code>true</code>, <code>false</code>, or <code>static</code></td>
 			<td><code>{{defaults.DEMO}}</code></td>
 			<td>
 				Displays plausible but randomly generated messages instead of a live

--- a/src/docs/configuration.html
+++ b/src/docs/configuration.html
@@ -31,8 +31,18 @@ description: All parameters for showmy.chat overlay URLs.
 			<td><code>true</code>, <code>false</code>, or <code>static</code></td>
 			<td><code>{{defaults.DEMO}}</code></td>
 			<td>
-				Displays plausible but randomly generated messages instead of a live
-				feed
+				<p>
+					Displays plausible but randomly generated messages instead of a live
+					feed.
+				</p>
+				<ul>
+					<li>
+						When <code>true</code>, new messages are added periodically.
+					</li>
+					<li>
+						When <code>static</code>, all messages are shown immediately and no messages are added.
+					</li>
+				</ul>
 			</td>
 		</tr>
 		<tr id="clear-message-after">

--- a/src/scripts/demo.mjs
+++ b/src/scripts/demo.mjs
@@ -143,7 +143,15 @@ const MOCK_COMFY = (function () {
 			if (channelNames.length) {
 				broadcaster.user = channelNames[0];
 			}
-			setTimeout(_generateNextMessage, 500);
+
+			// send all messages at once if the demo page is static
+			if (window.CONFIG.DEMO === 'static') {
+				for (let i = 0; i < window.CONFIG.showLatestMessages; i++) {
+					_generateNextMessage();
+				}
+			} else {
+				setTimeout(_generateNextMessage, 500);
+			}
 		},
 	};
 
@@ -258,11 +266,15 @@ const MOCK_COMFY = (function () {
 		messages.push(message);
 		comfy.onChat(...message);
 
-		// Ready up the next message
-		const duration = Math.floor(Math.random() * 4) + 3;
-		const nextGeneratedMessage =
-			Math.random() < 0.25 ? _generateChatCommand : _generateNextMessage;
-		setTimeout(nextGeneratedMessage, duration * 1000);
+		// do not send more messages if the demo page is static
+		if (window.CONFIG.DEMO !== 'static') {
+			// Ready up the next message
+			const nextGeneratedMessage =
+				Math.random() < 0.25 ? _generateChatCommand : _generateNextMessage;
+
+			const duration = Math.floor(Math.random() * 4) + 3;
+			setTimeout(nextGeneratedMessage, duration * 1000);
+		}
 	}
 
 	/**


### PR DESCRIPTION
relates to #66 and #69

Untabled the idea after a long break.

This PR adds a way to get a static DEMO page.
Useful when developing a theme so the message you are styling doesn't scroll off the page by new ones being added.

Much simpler implementation this time around, no special parameter handling as one extra possibility for a query parameter doesn't require added complexity there.

When `DEMO=static` is passed, the demo page generates the number of messages specified by the `showLatestMessages` (always present as it's set to 100 if not explicitly specified) option immediately and does not add more.

Demo of workflow:
URL used: `http://localhost:8080/c/showmychat?theme=advent-of-code&showLatestMessages=10&DEMO=static`
changing the color of a mentioned user from red to blue
![hQcKVVjdJz](https://user-images.githubusercontent.com/30179461/193599492-1cc93932-d14a-40c3-8e15-3da593f6ac0b.gif)

